### PR TITLE
Increase code size based on input size

### DIFF
--- a/src/autoencoder.py
+++ b/src/autoencoder.py
@@ -11,7 +11,7 @@ from .network import Confounded
 INPUT_PATH = "./data/GSE40292_copy.csv"
 OUTPUT_PATH = "./data/rna_seq_adj_test.csv"
 MINIBATCH_SIZE = 5
-CODE_SIZE = 200
+CODE_SIZE = 8000
 ITERATIONS = 10000
 
 def check_positive(value):
@@ -34,7 +34,7 @@ def autoencoder(input_path, output_path, minibatch_size=100, code_size=200, iter
 
     with tf.Session() as sess:
         merged = tf.summary.merge_all()
-        writer = tf.summary.FileWriter("log/test_file", sess.graph)
+        writer = tf.summary.FileWriter("log/big_network3", sess.graph)
         tf.global_variables_initializer().run()
 
         # Train

--- a/src/network.py
+++ b/src/network.py
@@ -36,15 +36,15 @@ class Confounded(object):
             if is_square_image:
                 self.show_image(self.inputs, "inputs")
             with tf.name_scope("encoding"):
-                encode1 = fully_connected(self.inputs, 512, activation_fn=tf.nn.relu)
+                encode1 = fully_connected(self.inputs, 2000, activation_fn=tf.nn.relu)
                 encode1 = batch_norm(encode1)
-                encode2 = fully_connected(encode1, 256, activation_fn=tf.nn.relu)
+                encode2 = fully_connected(encode1, 1000, activation_fn=tf.nn.relu)
                 encode2 = batch_norm(encode2)
                 code = fully_connected(encode2, self.code_size, activation_fn=tf.nn.relu)
             with tf.name_scope("decoding"):
-                decode1 = fully_connected(code, 256, activation_fn=tf.nn.relu)
+                decode1 = fully_connected(code, 1000, activation_fn=tf.nn.relu)
                 decode1 = batch_norm(decode1)
-                decode2 = fully_connected(decode1, 512, activation_fn=tf.nn.relu)
+                decode2 = fully_connected(decode1, 2000, activation_fn=tf.nn.relu)
                 decode2 = batch_norm(decode2)
                 self.outputs = fully_connected(decode2, self.input_size, activation_fn=tf.nn.sigmoid)
             if is_square_image:
@@ -65,13 +65,13 @@ class Confounded(object):
             with tf.name_scope("optimizer"):
                 d_loss = tf.losses.mean_squared_error(self.classification, self.targets)
                 tf.summary.scalar("mse", d_loss)
-                self.d_optimizer = tf.train.AdamOptimizer(learning_rate=0.0001).minimize(d_loss)
+                self.d_optimizer = tf.train.AdamOptimizer(learning_rate=0.001).minimize(d_loss)
         with tf.name_scope("autoencoder"):
             with tf.name_scope("optimizer"):
                 mse = tf.losses.mean_squared_error(self.inputs, self.outputs)
                 tf.summary.scalar("mse", mse)
                 loss = mse + (tf.ones_like(d_loss) - d_loss)
-                self.optimizer = tf.train.AdamOptimizer(learning_rate=0.0001).minimize(loss)
+                self.optimizer = tf.train.AdamOptimizer(learning_rate=0.001).minimize(loss)
 
     def show_image(self, x, name="image"):
         # This assumes the input is a square image...


### PR DESCRIPTION
Bigger feature sets probably require bigger code sizes. (Maybe ~`sqrt(input_size)`?) We want to automatically adjust this for bigger input sizes.

Ideally we can do this without making it infeasible without large amounts of memory.

And maybe we should also adjust the sizes of the other layers?

Closes #48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jdayton3/confounded/50)
<!-- Reviewable:end -->
